### PR TITLE
Enable include_router per router CORS

### DIFF
--- a/src/extensions/ext_blueprints.py
+++ b/src/extensions/ext_blueprints.py
@@ -14,4 +14,4 @@ def init_app(app: DNikoApp):
         allow_headers=["Content-Type", "Authorization", "X-App-Code"],
         expose_headers=["X-Version", "X-Env"],
         allow_methods=["GET", "PUT", "POST", "DELETE", "OPTIONS", "PATCH"],
-    ).mount_to(app)
+    ).include_in(app)


### PR DESCRIPTION
## Summary
- allow using per-router CORS middleware without losing docs
- add `include_in` helper that attaches prefix-aware middleware
- switch console blueprint to use `include_in`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685faeffa22c8321aab92038e382b317