### PR TITLE
Organize controllers

### DIFF
--- a/src/app_factory.py
+++ b/src/app_factory.py
@@ -14,7 +14,6 @@ def create_fast_api_app():
 def create_app() -> DNikoApp:
     app = create_fast_api_app()
     initialize_extensions(app)
-    ext_blueprints.init_app(app)
     return app
 
 

--- a/src/config/deploy/__init__.py
+++ b/src/config/deploy/__init__.py
@@ -32,3 +32,8 @@ class DeploymentConfig(BaseSettings):
         description="Deployment environment (e.g., 'PRODUCTION', 'DEVELOPMENT'), default to PRODUCTION",
         default="PRODUCTION",
     )
+
+    API_VERSION: str = Field(
+        description="Deployment edition of the application (e.g., 'SELF_HOSTED', 'CLOUD')",
+        default="v1",
+    )

--- a/src/controllers/__init__.py
+++ b/src/controllers/__init__.py
@@ -1,12 +1,14 @@
 from fastapi import APIRouter
 
+from .constants import API_VERSION
+
 from .ui import router as ui_router
 from .vendors import router as vendors_router
 from .public_api import router as public_api_router
 from .platform import router as platform_router
 from .system import router as system_router
 
-router = APIRouter()
+router = APIRouter(prefix=f"/api/{API_VERSION}")
 
 router.include_router(system_router)
 router.include_router(ui_router)

--- a/src/controllers/__init__.py
+++ b/src/controllers/__init__.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter
 
+from config import d_niko_config
 from .constants import API_VERSION
 
 from .console import router as console_router
@@ -11,7 +12,7 @@ from .public_api import router as public_api_router
 from .platform import router as platform_router
 from .system import router as system_router
 
-router = APIRouter(prefix=f"/api/{API_VERSION}")
+router = APIRouter(prefix=f"/api/{d_niko_config.API_VERSION}")
 
 router.include_router(system_router)
 router.include_router(console_router)

--- a/src/controllers/__init__.py
+++ b/src/controllers/__init__.py
@@ -1,0 +1,15 @@
+from fastapi import APIRouter
+
+from .ui import router as ui_router
+from .vendors import router as vendors_router
+from .public_api import router as public_api_router
+from .platform import router as platform_router
+from .system import router as system_router
+
+router = APIRouter()
+
+router.include_router(system_router)
+router.include_router(ui_router)
+router.include_router(vendors_router)
+router.include_router(public_api_router)
+router.include_router(platform_router)

--- a/src/controllers/__init__.py
+++ b/src/controllers/__init__.py
@@ -2,7 +2,10 @@ from fastapi import APIRouter
 
 from .constants import API_VERSION
 
-from .ui import router as ui_router
+from .console import router as console_router
+from .client import router as client_router
+from .client_mobile import router as client_mobile_router
+from .client_twa import router as client_twa_router
 from .vendors import router as vendors_router
 from .public_api import router as public_api_router
 from .platform import router as platform_router
@@ -11,7 +14,10 @@ from .system import router as system_router
 router = APIRouter(prefix=f"/api/{API_VERSION}")
 
 router.include_router(system_router)
-router.include_router(ui_router)
+router.include_router(console_router)
+router.include_router(client_router)
+router.include_router(client_mobile_router)
+router.include_router(client_twa_router)
 router.include_router(vendors_router)
 router.include_router(public_api_router)
 router.include_router(platform_router)

--- a/src/controllers/client/__init__.py
+++ b/src/controllers/client/__init__.py
@@ -1,0 +1,9 @@
+from fastapi import APIRouter
+
+from . import auth, orders, profile
+
+router = APIRouter(prefix="/client", tags=["client"])
+
+router.include_router(auth.router)
+router.include_router(orders.router)
+router.include_router(profile.router)

--- a/src/controllers/client/auth.py
+++ b/src/controllers/client/auth.py
@@ -1,0 +1,11 @@
+from fastapi import APIRouter
+
+router = APIRouter()
+
+@router.post('/login')
+async def login():
+    return {"status": "logged in"}
+
+@router.post('/refresh')
+async def refresh():
+    return {"status": "refreshed"}

--- a/src/controllers/client/orders.py
+++ b/src/controllers/client/orders.py
@@ -1,0 +1,7 @@
+from fastapi import APIRouter
+
+router = APIRouter()
+
+@router.get('/orders')
+async def list_orders():
+    return {"orders": []}

--- a/src/controllers/client/profile.py
+++ b/src/controllers/client/profile.py
@@ -1,0 +1,7 @@
+from fastapi import APIRouter
+
+router = APIRouter()
+
+@router.get('/profile')
+async def profile_info():
+    return {"profile": "info"}

--- a/src/controllers/client_mobile/__init__.py
+++ b/src/controllers/client_mobile/__init__.py
@@ -1,0 +1,7 @@
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/client/mobile", tags=["client_mobile"])
+
+@router.get('/ping')
+async def mobile_ping():
+    return {"mobile": "pong"}

--- a/src/controllers/client_twa/__init__.py
+++ b/src/controllers/client_twa/__init__.py
@@ -1,0 +1,7 @@
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/client/twa", tags=["client_twa"])
+
+@router.post('/callback')
+async def twa_callback():
+    return {"twa": "callback"}

--- a/src/controllers/console/__init__.py
+++ b/src/controllers/console/__init__.py
@@ -1,5 +1,0 @@
-from fastapi import APIRouter
-
-router = APIRouter(prefix="/console", tags=["console"])
-
-from . import ping

--- a/src/controllers/console/__init__.py
+++ b/src/controllers/console/__init__.py
@@ -1,0 +1,7 @@
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/console", tags=["console"])
+
+@router.get("/dashboard")
+async def dashboard_example():
+    return {"message": "console dashboard"}

--- a/src/controllers/console/ping.py
+++ b/src/controllers/console/ping.py
@@ -1,6 +1,0 @@
-from controllers.console import router
-
-
-@router.get("/ping")
-async def ping():
-    return "pong"

--- a/src/controllers/constants.py
+++ b/src/controllers/constants.py
@@ -1,0 +1,2 @@
+API_VERSION = "v1"
+"""Current API version prefix."""

--- a/src/controllers/platform/__init__.py
+++ b/src/controllers/platform/__init__.py
@@ -1,0 +1,13 @@
+from fastapi import APIRouter
+
+from .licensing import router as licensing_router
+from .billing import router as billing_router
+from .admin import router as admin_router
+from .webhook_receiver import router as webhook_router
+
+router = APIRouter(prefix="/platform", tags=["platform"])
+
+router.include_router(licensing_router)
+router.include_router(billing_router)
+router.include_router(admin_router)
+router.include_router(webhook_router)

--- a/src/controllers/platform/admin/__init__.py
+++ b/src/controllers/platform/admin/__init__.py
@@ -1,0 +1,9 @@
+from fastapi import APIRouter
+
+from .plans import router as plans_router
+from .invoices import router as invoices_router
+
+router = APIRouter(prefix="/admin", tags=["platform_admin"])
+
+router.include_router(plans_router)
+router.include_router(invoices_router)

--- a/src/controllers/platform/admin/invoices.py
+++ b/src/controllers/platform/admin/invoices.py
@@ -1,0 +1,8 @@
+from fastapi import APIRouter
+
+router = APIRouter()
+
+
+@router.get("/invoices")
+async def list_invoices():
+    return {"invoices": []}

--- a/src/controllers/platform/admin/plans.py
+++ b/src/controllers/platform/admin/plans.py
@@ -1,0 +1,8 @@
+from fastapi import APIRouter
+
+router = APIRouter()
+
+
+@router.get("/plans")
+async def list_plans():
+    return {"plans": []}

--- a/src/controllers/platform/billing.py
+++ b/src/controllers/platform/billing.py
@@ -1,0 +1,8 @@
+from fastapi import APIRouter
+
+router = APIRouter()
+
+
+@router.get("/subscription")
+async def subscription_info():
+    return {"subscription": "active"}

--- a/src/controllers/platform/licensing.py
+++ b/src/controllers/platform/licensing.py
@@ -1,0 +1,8 @@
+from fastapi import APIRouter
+
+router = APIRouter()
+
+
+@router.get("/license/status")
+async def license_status():
+    return {"status": "ok"}

--- a/src/controllers/platform/webhook_receiver.py
+++ b/src/controllers/platform/webhook_receiver.py
@@ -1,0 +1,8 @@
+from fastapi import APIRouter
+
+router = APIRouter()
+
+
+@router.post("/webhook/payment-succeeded")
+async def payment_succeeded():
+    return {"status": "received"}

--- a/src/controllers/public_api/__init__.py
+++ b/src/controllers/public_api/__init__.py
@@ -1,0 +1,8 @@
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/public", tags=["public"])
+
+
+@router.post("/webhook")
+async def public_webhook():
+    return {"message": "webhook received"}

--- a/src/controllers/system/__init__.py
+++ b/src/controllers/system/__init__.py
@@ -1,0 +1,23 @@
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/system", tags=["system"])
+
+
+@router.get("/ping")
+async def ping():
+    return {"status": "ok"}
+
+
+@router.get("/readiness")
+async def readiness_probe():
+    return {"status": "ready"}
+
+
+@router.get("/liveness")
+async def liveness_probe():
+    return {"status": "alive"}
+
+
+@router.get("/metrics")
+async def metrics():
+    return {"metrics": "placeholder"}

--- a/src/controllers/ui/__init__.py
+++ b/src/controllers/ui/__init__.py
@@ -1,8 +1,0 @@
-from fastapi import APIRouter
-
-router = APIRouter(prefix="/ui", tags=["ui"])
-
-
-@router.get("/dashboard")
-async def dashboard_example():
-    return {"message": "ui dashboard"}

--- a/src/controllers/ui/__init__.py
+++ b/src/controllers/ui/__init__.py
@@ -1,0 +1,8 @@
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/ui", tags=["ui"])
+
+
+@router.get("/dashboard")
+async def dashboard_example():
+    return {"message": "ui dashboard"}

--- a/src/controllers/vendors/__init__.py
+++ b/src/controllers/vendors/__init__.py
@@ -1,0 +1,13 @@
+from fastapi import APIRouter
+
+from .bitrix import router as bitrix_router
+from .dify import router as dify_router
+from .payments import router as payments_router
+from .ca import router as ca_router
+
+router = APIRouter(prefix="/vendors", tags=["vendors"])
+
+router.include_router(bitrix_router)
+router.include_router(dify_router)
+router.include_router(payments_router)
+router.include_router(ca_router)

--- a/src/controllers/vendors/bitrix/__init__.py
+++ b/src/controllers/vendors/bitrix/__init__.py
@@ -1,0 +1,8 @@
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/bitrix", tags=["bitrix"])
+
+
+@router.get("/example")
+async def bitrix_example():
+    return {"message": "bitrix placeholder"}

--- a/src/controllers/vendors/ca/__init__.py
+++ b/src/controllers/vendors/ca/__init__.py
@@ -1,0 +1,8 @@
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/ca", tags=["ca"])
+
+
+@router.get("/example")
+async def ca_example():
+    return {"message": "ca placeholder"}

--- a/src/controllers/vendors/dify/__init__.py
+++ b/src/controllers/vendors/dify/__init__.py
@@ -1,0 +1,8 @@
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/dify", tags=["dify"])
+
+
+@router.get("/example")
+async def dify_example():
+    return {"message": "dify placeholder"}

--- a/src/controllers/vendors/payments/__init__.py
+++ b/src/controllers/vendors/payments/__init__.py
@@ -1,0 +1,8 @@
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/payments", tags=["payments"])
+
+
+@router.get("/example")
+async def payments_example():
+    return {"message": "payments placeholder"}

--- a/src/extensions/ext_blueprints.py
+++ b/src/extensions/ext_blueprints.py
@@ -1,5 +1,5 @@
-from controllers.console import router as console_router
+from controllers import router as api_router
 
 
 def init_app(app):
-    app.include_router(console_router)
+    app.include_router(api_router)


### PR DESCRIPTION
## Summary
- reorganize controllers with subpackages for UI, vendors, platform, public API and system endpoints
- add placeholder routes demonstrating each controller
- update router aggregator to include new packages

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685fd1cef810832191cc6a3435a90e33